### PR TITLE
Modification des loggers pour le setting et la modularité

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
     module = module_from_spec(spec)
     spec.loader.exec_module(module)
 
-    logger = setup_logger(level=logging.INFO)
+    logger = setup_logger()
 
     start = datetime.now()
 

--- a/src/settings.py
+++ b/src/settings.py
@@ -1,3 +1,6 @@
+import logging
+import typing
 from pathlib import Path
 
 DATA_FOLDER: Path = Path.cwd() / "src" / "data"
+LOGGER_LEVEL: typing.Final = logging.INFO

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -1,6 +1,8 @@
 import json
 import logging
 
+import src.settings as settings
+
 
 class JsonlFormatter(logging.Formatter):
     def format(self, record) -> str:
@@ -17,17 +19,17 @@ class JsonlFormatter(logging.Formatter):
 
 
 def setup_logger(
-    level: int = logging.INFO,
+    level: int = settings.LOGGER_LEVEL,
     datefmt: str = "%Y-%m-%d %H:%M:%S",
     format: str = "%(asctime)s - %(levelname)s - %(name)s|%(funcName)s:%(lineno)d - %(message)s",
+    name: str = "main",
 ):
     """Configuration globale du logger"""
-    logger = logging.getLogger()
+    logger = logging.getLogger(name)
     logger.setLevel(level)
 
     # logger console
     log_console = logging.StreamHandler()
-    log_console.setLevel(logging.INFO)
     log_console.setFormatter(logging.Formatter(format))
     logger.addHandler(log_console)
 


### PR DESCRIPTION
Voici une petite PR, comme ça Thibault tu seras content ; ) (Et cette fois ci avec le pre-commit)

Plus sérieusement, dans cette PR j'ai changé plusieurs petites choses :

- Ajout d'un nom pour le logger dans la fonction utils.src.logger.setup_logger, celui-ci pourra être réutilisé pour get_logger
    - Utilité : Permet de logger dans différent modules (utiles quand il y aura plusieurs modules ensembles)
- Changement du niveau de logger :
    - Suppression du niveau de log INFO pour le handler Commande
    - Le niveau de log n'est plus définis dans les paramètres implicites de la fonction utils.src.logger.setup_logger mais dans src.settings.LOGGER_LEVEL
    - Utilité : Changer le niveau de log très facilement au lieu d'aller chercher dans chaques fichiers

Certes c'est une petite PR, mais je devais l'envoyer avant de travailler sur la fameuse pipeline
