### PR TITLE
feat: ProcessorMixin v2?

### DIFF
--- a/src/utils/processor_mixin.py
+++ b/src/utils/processor_mixin.py
@@ -25,14 +25,12 @@ class ProcessorMixin:
     def run(
         cls,
         reload_pipeline: bool = False,
-        content: Any = None,
         fetch_api_kwargs: dict | None = None,
         fetch_input_kwargs: dict | None = None,
         fetch_output_kwargs: dict | None = None,
     ) -> None:
         content = cls.fetch(
             reload_pipeline=reload_pipeline,
-            content=None,
             fetch_api_kwargs=fetch_api_kwargs,
             fetch_input_kwargs=fetch_input_kwargs,
             fetch_output_kwargs=fetch_output_kwargs,
@@ -44,7 +42,6 @@ class ProcessorMixin:
     def fetch(
         cls,
         reload_pipeline: bool = False,
-        content: Any = None,
         fetch_api_kwargs: dict | None = None,
         fetch_input_kwargs: dict | None = None,
         fetch_output_kwargs: dict | None = None,
@@ -63,7 +60,7 @@ class ProcessorMixin:
         fetch_output_kwargs = fetch_output_kwargs or dict()
 
         if reload_pipeline:
-            api_content = cls.fetch_and_save_from_api(content, **fetch_api_kwargs)
+            api_content = cls.fetch_and_save_from_api(**fetch_api_kwargs)
             input_content = cls.fetch_and_save_from_input_file(
                 api_content, **fetch_input_kwargs
             )

--- a/src/utils/processor_mixin.py
+++ b/src/utils/processor_mixin.py
@@ -86,23 +86,39 @@ class ProcessorMixin:
             content = cls.fetch_from_api()
 
         if save and cls.input_file:
-            cls.save(content, cls.input_file)
+            if content is None:
+                logger.error(f"{cls.__name__}: cannot save because `content` attribute is None")
+            else:
+                cls.input_file.parent.mkdir(parents=True, exist_ok=True)
+                cls.save(content, cls.input_file)
         return content
 
     @classmethod
     def fetch_and_save_from_input_file(cls, content=None, save: bool = True):
         if content is None and cls.input_file:
-            content = cls.fetch_from_file(cls.input_file)
+            if cls.input_file.exists():
+                content = cls.fetch_from_file(cls.input_file)
+            else:
+                logger.warning(f"{cls.__name__}: {cls.input_file} does not exist")
 
         processed = cls.pre_process(content)
         if save and cls.output_file:
-            cls.save(processed, cls.output_file)
+            if processed is None:
+                logger.error(
+                    f"{cls.__name__}: cannot save because `processed` attribute is None"
+                )
+            else:
+                cls.output_file.parent.mkdir(parents=True, exist_ok=True)
+                cls.save(processed, cls.output_file)
         return processed
 
     @classmethod
     def fetch_from_output_file(cls, content=None):
         if content is None and cls.output_file:
-            content = cls.fetch_from_file(cls.output_file)
+            if cls.output_file.exists():
+                content = cls.fetch_from_file(cls.output_file)
+            else:
+                logger.warning(f"{cls.__name__}: {cls.output_file} does not exist")
 
         return cls.post_process(content)
 
@@ -112,18 +128,11 @@ class ProcessorMixin:
 
     @classmethod
     def fetch_from_file(cls, path: Path, **kwargs):
-        if not path.exists():
-            logger.warning(f"{cls.__name__}: {path} does not exist")
-            return
-        # TODO: logic
+        raise NotImplementedError
 
     @classmethod
     def save(cls, content, path: Path) -> None:
-        if content is None:
-            logger.error(f"{cls.__name__}: cannot save because `content` attribute is None")
-            return
-        path.parent.mkdir(parents=True, exist_ok=True)
-        # TODO: logic
+        raise NotImplementedError
 
     @classmethod
     def pre_process(cls, content, **kwargs):

--- a/src/utils/processor_mixin.py
+++ b/src/utils/processor_mixin.py
@@ -9,7 +9,8 @@ class ProcessorMixin:
     """
     api_class est la classe de l'API
     input_file va permettre de trouver le fichier d'entrée, sauvegarde non modifiée de l'api_class
-    output_file va permettre de trouver le fichier de sortie, sauvegarde modifiée de l'input_file
+    output_file va permettre de trouver le fichier de sortie, sauvegarde de l'input_file modifiée par `pre_process`
+    la data en sortie est le contenu de l'output_file sur lequel on a appliqué `post_process`
     """
 
     api_class: Type | None = None
@@ -50,8 +51,8 @@ class ProcessorMixin:
         Récupère la donnée et la sauvegarde si besoin
         Il existe 3 niveaux d'informations : celle de l'api, celle de l'input_file et celle de l'output_file
         Lors d'un process où `reload_pipeline` is False (cas par défaut) :
-            - on va regarder l'output_file, s'il n'existe pas ou s'il n'est pas configuré
-            - on va regarder l'input_file, que l'on va procésser, s'il n'existe pas ou s'il n'est pas configuré
+            - on va regarder l'output_file, sur lequel on va appliquer `postprocess`, s'il n'existe pas ou s'il n'est pas configuré
+            - on va regarder l'input_file, sur lequel on va appliquer `preprocess`, s'il n'existe pas ou s'il n'est pas configuré
             - on va regarder l'api_class, pour télécharger la donnée et la sauvegarder
         Lors d'un process où `reload_pipeline` is True, le process est inversé
         """

--- a/src/utils/processor_mixin.py
+++ b/src/utils/processor_mixin.py
@@ -46,7 +46,7 @@ class ProcessorMixin:
         fetch_api_kwargs: dict | None = None,
         fetch_input_kwargs: dict | None = None,
         fetch_output_kwargs: dict | None = None,
-    ) -> Any:
+    ) -> Any | None:
         """
         Récupère la donnée et la sauvegarde si besoin
         Il existe 3 niveaux d'informations : celle de l'api, celle de l'input_file et celle de l'output_file
@@ -81,7 +81,9 @@ class ProcessorMixin:
         return output_content
 
     @classmethod
-    def fetch_and_save_from_api(cls, content=None, save: bool = True):
+    def fetch_and_save_from_api(
+        cls, content: Any | None = None, save: bool = True
+    ) -> Any | None:
         if content is None and cls.api_class:
             content = cls.fetch_from_api()
 
@@ -94,7 +96,9 @@ class ProcessorMixin:
         return content
 
     @classmethod
-    def fetch_and_save_from_input_file(cls, content=None, save: bool = True):
+    def fetch_and_save_from_input_file(
+        cls, content: Any | None = None, save: bool = True
+    ) -> Any | None:
         if content is None and cls.input_file:
             if cls.input_file.exists():
                 content = cls.fetch_from_file(cls.input_file)
@@ -113,7 +117,7 @@ class ProcessorMixin:
         return processed
 
     @classmethod
-    def fetch_from_output_file(cls, content=None):
+    def fetch_from_output_file(cls, content: Any | None = None) -> Any | None:
         if content is None and cls.output_file:
             if cls.output_file.exists():
                 content = cls.fetch_from_file(cls.output_file)
@@ -131,13 +135,13 @@ class ProcessorMixin:
         raise NotImplementedError
 
     @classmethod
-    def save(cls, content, path: Path) -> None:
+    def save(cls, content: Any, path: Path) -> None:
         raise NotImplementedError
 
     @classmethod
-    def pre_process(cls, content, **kwargs):
+    def pre_process(cls, content: Any | None, **kwargs) -> Any | None:
         return content
 
     @classmethod
-    def post_process(cls, content, **kwargs):
+    def post_process(cls, content: Any | None, **kwargs) -> Any | None:
         return content

--- a/src/utils/processor_mixin.py
+++ b/src/utils/processor_mixin.py
@@ -1,10 +1,13 @@
+import logging
 from pathlib import Path
-from typing import Type
+from typing import Any, Type
+
+logger = logging.getLogger(__name__)
 
 
 class ProcessorMixin:
     """
-    api_class va permettre d'aller récupérer la donnée en ligne
+    api_class est la classe de l'API
     input_file va permettre de trouver le fichier d'entrée, sauvegarde non modifiée de l'api_class
     output_file va permettre de trouver le fichier de sortie, sauvegarde modifiée de l'input_file
     """
@@ -19,57 +22,91 @@ class ProcessorMixin:
         raise Exception("Utility class")
 
     @classmethod
-    def run(cls, reload_pipeline: bool = False) -> None:
-        content = cls.fetch(reload_pipeline=reload_pipeline)
-
-        if cls.output_file and (reload_pipeline or not cls.output_file.exists()):
-            cls.save(content, cls.output_file)
+    def run(
+        cls,
+        reload_pipeline: bool = False,
+        content: Any = None,
+        fetch_api_kwargs: dict | None = None,
+        fetch_input_kwargs: dict | None = None,
+        fetch_output_kwargs: dict | None = None,
+    ) -> None:
+        content = cls.fetch(
+            reload_pipeline=reload_pipeline,
+            content=None,
+            fetch_api_kwargs=fetch_api_kwargs,
+            fetch_input_kwargs=fetch_input_kwargs,
+            fetch_output_kwargs=fetch_output_kwargs,
+        )
+        if content is None:
+            logger.warning(f"{cls.__name__}: have no content")
 
     @classmethod
-    def fetch(cls, reload_pipeline: bool = False) -> list:
+    def fetch(
+        cls,
+        reload_pipeline: bool = False,
+        content: Any = None,
+        fetch_api_kwargs: dict | None = None,
+        fetch_input_kwargs: dict | None = None,
+        fetch_output_kwargs: dict | None = None,
+    ) -> Any:
         """
         Récupère la donnée et la sauvegarde si besoin
         Il existe 3 niveaux d'informations : celle de l'api, celle de l'input_file et celle de l'output_file
         Lors d'un process où `reload_pipeline` is False (cas par défaut) :
             - on va regarder l'output_file, s'il n'existe pas ou s'il n'est pas configuré
             - on va regarder l'input_file, que l'on va procésser, s'il n'existe pas ou s'il n'est pas configuré
-            - on va regarder l'api_class, pour télécharger la donnée et la sauvegarder, s'il n'existe pas, une exception est levée
+            - on va regarder l'api_class, pour télécharger la donnée et la sauvegarder
         Lors d'un process où `reload_pipeline` is True, le process est inversé
         """
+        fetch_api_kwargs = fetch_api_kwargs or dict()
+        fetch_input_kwargs = fetch_input_kwargs or dict()
+        fetch_output_kwargs = fetch_output_kwargs or dict()
 
-        # TODO: fetch_from_api si le fichier de l'url a été mis à jour
-        def fetch_from_api():
-            if cls.api_class:
-                content = cls.fetch_from_api()
-                if cls.input_file:
-                    cls.save(content, cls.input_file)
-                return fetch_from_loaded_input_file(content)
+        if reload_pipeline:
+            api_content = cls.fetch_and_save_from_api(content, **fetch_api_kwargs)
+            input_content = cls.fetch_and_save_from_input_file(
+                api_content, **fetch_input_kwargs
+            )
+            output_content = cls.fetch_from_output_file(input_content, **fetch_output_kwargs)
+        else:
+            output_content = cls.fetch_from_output_file(**fetch_output_kwargs)
+            if output_content is None:
+                input_content = cls.fetch_and_save_from_input_file(**fetch_input_kwargs)
+                if input_content is None:
+                    api_content = cls.fetch_and_save_from_api(**fetch_api_kwargs)
+                    input_content = cls.fetch_and_save_from_input_file(
+                        api_content, **fetch_input_kwargs
+                    )
+                output_content = cls.fetch_from_output_file(
+                    input_content, **fetch_output_kwargs
+                )
+        return output_content
 
-        def fetch_from_loaded_input_file(content):
-            processed = cls.pre_process(content)
-            if cls.output_file:
-                cls.save(processed, cls.output_file)
-            return processed
+    @classmethod
+    def fetch_and_save_from_api(cls, content=None, save: bool = True):
+        if content is None and cls.api_class:
+            content = cls.fetch_from_api()
 
-        def fetch_from_input_file():
-            if cls.input_file and cls.input_file.exists():
-                content = cls.fetch_from_file(cls.input_file)
-                return fetch_from_loaded_input_file(content)
+        if save and cls.input_file:
+            cls.save(content, cls.input_file)
+        return content
 
-        def fetch_from_output_file():
-            if cls.output_file and cls.output_file.exists():
-                return cls.fetch_from_file(cls.output_file)
+    @classmethod
+    def fetch_and_save_from_input_file(cls, content=None, save: bool = True):
+        if content is None and cls.input_file:
+            content = cls.fetch_from_file(cls.input_file)
 
-        methods = [fetch_from_api, fetch_from_input_file, fetch_from_output_file]
-        if not reload_pipeline:
-            methods = methods[::-1]
+        processed = cls.pre_process(content)
+        if save and cls.output_file:
+            cls.save(processed, cls.output_file)
+        return processed
 
-        for method in methods:
-            content = method()
-            if content is not None:
-                return content
+    @classmethod
+    def fetch_from_output_file(cls, content=None):
+        if content is None and cls.output_file:
+            content = cls.fetch_from_file(cls.output_file)
 
-        raise Exception
+        return cls.post_process(content)
 
     @classmethod
     def fetch_from_api(cls, **kwargs):
@@ -77,12 +114,23 @@ class ProcessorMixin:
 
     @classmethod
     def fetch_from_file(cls, path: Path, **kwargs):
-        raise NotImplementedError
+        if not path.exists():
+            logger.warning(f"{cls.__name__}: {path} does not exist")
+            return
+        # TODO: logic
 
     @classmethod
     def save(cls, content, path: Path) -> None:
+        if content is None:
+            logger.error(f"{cls.__name__}: cannot save because `content` attribute is None")
+            return
         path.parent.mkdir(parents=True, exist_ok=True)
+        # TODO: logic
 
     @classmethod
     def pre_process(cls, content, **kwargs):
+        return content
+
+    @classmethod
+    def post_process(cls, content, **kwargs):
         return content


### PR DESCRIPTION
Refonte partielle de `ProcessorMixin`.
Ce n'est sans doute toujours pas adapté aux données TDG qui a un fonctionnement bien spécifique.
On peut avoir un workflow qui encapsule ProcessorMixin plutôt qu'un héritage contraignant (des modifs sont nécessaires).
Tout ceci n'est que proposition, c'est vous qui avez l'expérience terrain donc je n'ai pas poussé la logique loin.

On a toujours 3 sources de données. Entre chaque étape, on a une méthode pour l'altérer.
API → input_file → preprocess → output_file → post_process → data
(un vrai schéma serait le bienvenue avec le nom des méthodes)

Si `reload_pipeline` vaut True alors la méthode `fetch` réapplique toute la logique, la donnée est retéléchargée et les fichiers écrasés.
Sinon, elle exécute un minimum du process.
En sortie, la donnée doit toujours être identique, peu importe l'endroit d'où la logique a démarré.

Il n'y a pas de process entre l'API et le input_file, l'idée ici est que la donnée soit sauvegardée telle quelle pour pouvoir modifier les process sans avoir à retélécharger la donnée.
Si c'est pas acceptable, comme dans le cas de OSM (fichier data trop lourd), il suffirait de mettre `intput_file` à `None` et de renseigner `output_file` puis de mettre la logique dans le `preprocess`.

À chaque étape du processus, on transmet la donnée à l'étape suivante (via le paramètre `content`).
Cela permet notamment de ne pas surcharger la mémoire (actuellement, on save dans l'input_file pour ensuite lire ce même fichier, on a donc chargé deux fois la data). C'est aussi utile pour des tests.

À chaque étape on peut choisir si on sauvegarde la data ou non (via le paramètre `save`).

Ajout des attributs `fetch_api_kwargs`, `fetch_input_kwargs`, `fetch_output_kwargs` pour transmettre des options pour les méthodes correspondantes. Utile, mais lourd.

Pas pensé pour télécharger plusieurs fichiers comme dans le cas de TDG.
Je suis ouvert aux alternatives.
Sinon on peut instancier la classe de façon à pouvoir overrider les attributs et ainsi pouvoir itérer dessus (on resterait sur une logique à un fichier mais répétable).

La gestion du `timeout` et du `max_retries` me paraît plus indiqué à mettre dans l'`api_class`.

La classe utilitaire montre doublement ses limites.